### PR TITLE
Test all supported Python versions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,9 @@
 [run]
 source = z3c.currency
 omit = */test*
+
+[paths]
+source =
+   src/z3c/currency
+   .tox/*/lib/python*/site-packages/z3c/currency
+   .tox/pypy*/site-packages/z3c/currency

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ src/*.egg-info
 .tox/
 .coverage
 .eggs
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
+python:
+    - 2.7
+    - 3.6
+    - pypy
+    - pypy3
 matrix:
     include:
-        - os: linux
-          python: 2.7
-        #- os: linux
-        #  python: 3.6
-        - os: linux
-          python: 3.7
+        - python: 3.7
           dist: xenial
           sudo: true
-        - os: linux
-          python: pypy
-        #- os: linux
-        #  python: pypy3
 
 install:
     - travis_retry pip install .[form,test] z3c.form
@@ -25,4 +21,4 @@ notifications:
     email: false
 
 after_success:
-  - coveralls
+    - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ matrix:
           sudo: true
 
 install:
-    - travis_retry pip install .[form,test] z3c.form
-    - travis_retry pip install coverage coveralls tox zope.testing
+    - pip install .[form,test]
+    - pip install coverage coveralls zope.testrunner
 
 script:
-    - coverage run setup.py test -q
+    - coverage run -m zope.testrunner --test-path=src -vc
 
 notifications:
     email: false

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,9 @@ envlist =
 
 [testenv]
 commands =
-    coverage run setup.py test -q
+    coverage run -m zope.testrunner --test-path=src {posargs:-v}
 deps =
     .[form,test]
-    z3c.form
-    zope.testing
     zope.testrunner
     coverage
 setenv =
@@ -23,3 +21,5 @@ commands =
     coverage erase
     coverage combine
     coverage report
+deps =
+    coverage

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     z3c.form
     zope.testing
     zope.testrunner
+    coverage
 setenv =
    COVERAGE_FILE=.coverage.{envname}
 


### PR DESCRIPTION
Switches to zope.testrunner because life's too short to debug setup.py test failures on Python 3.6 & PyPy3.

Also fixes tox.ini to install `coverage` (since it wants to run it), and fixes coverage reporting to aggregate the results into one set of source modules (rather than repeat them in each toxenv).